### PR TITLE
Module auto cut drogue performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,3 +16,4 @@ jobs:
     uses: KSPModdingLibs/KSPBuildTools/.github/workflows/build.yml@main
     with:
       solution-file-path: 'Source/KSPCommunityPartModules.sln'
+      use-ckan: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,3 +13,4 @@ jobs:
     with:
       solution-file-path: 'Source/KSPCommunityPartModules.sln'
       version-string: ${{ inputs.version-string }}
+      use-ckan: true

--- a/GameData/KSPCommunityPartModules/KSPCommunityPartModules.ckan
+++ b/GameData/KSPCommunityPartModules/KSPCommunityPartModules.ckan
@@ -9,6 +9,8 @@ description: >-
 
   This mod is meant as community project, so feel free to propose additional module ideas by opening an issue, or contribute with a pull request on GitHub.
 ksp_version_min: '1.12.3'
+depends:
+  - name: Harmony2
 supports:
   - name: BoringCrewServices
   - name: BluedogDB

--- a/Source/KSPCommunityPartModules.csproj
+++ b/Source/KSPCommunityPartModules.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="KSPBuildTools" Version="0.0.2-alpha.5" />
+    <PackageReference Include="KSPBuildTools" Version="0.0.2-alpha.7" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Modules\ModuleAutoCutDrogue.cs" />
@@ -41,6 +41,11 @@
   <ItemGroup>
     <Content Include="HOW_TO_BUILD.txt" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Reference Include="$(KSPRoot)/GameData/000_Harmony/0Harmony.dll">
+      <Private>False</Private>
+      <CKANIdentifier>Harmony2</CKANIdentifier>
+    </Reference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/Modules/ModuleAutoCutDrogue.cs
+++ b/Source/Modules/ModuleAutoCutDrogue.cs
@@ -51,14 +51,17 @@ namespace KSPCommunityPartModules.Modules
 
         private void OnParachuteDeployed(ModuleParachute pChute)
         {
-            if (pChute == chute && !triggered && lastFrame != Time.frameCount)
+            if (pChute == chute && !triggered)
             {
-                var drogues = vessel.FindPartModulesImplementing<ModuleAutoCutDrogue>().Where(d => d.isDrogueChute && d.chute != null);
-                foreach (ModuleAutoCutDrogue d in drogues)
+                if (lastFrame != Time.frameCount)
                 {
-                    if (IsChuteDeployed(d.chute)) d.chute.CutParachute();
+                    var drogues = vessel.FindPartModulesImplementing<ModuleAutoCutDrogue>().Where(d => d.isDrogueChute && d.chute != null);
+                    foreach (ModuleAutoCutDrogue d in drogues)
+                    {
+                        if (IsChuteDeployed(d.chute)) d.chute.CutParachute();
+                    }
+                    lastFrame = Time.frameCount;
                 }
-                lastFrame = Time.frameCount;
                 triggered = true;
             }
         }

--- a/Source/Modules/ModuleAutoCutDrogue.cs
+++ b/Source/Modules/ModuleAutoCutDrogue.cs
@@ -68,7 +68,7 @@ namespace KSPCommunityPartModules.Modules
 
         private void OnParachuteRepacked(ModuleParachute pChute)
         {
-            if (pChute == chute && triggered) triggered = false;
+            if (triggered && pChute == chute) triggered = false;
         }
     }
 

--- a/Source/Modules/ModuleAutoCutDrogue.cs
+++ b/Source/Modules/ModuleAutoCutDrogue.cs
@@ -51,7 +51,7 @@ namespace KSPCommunityPartModules.Modules
 
         private void OnParachuteDeployed(ModuleParachute pChute)
         {
-            if (pChute == chute && !triggered)
+            if (autoCutDrogue && !triggered && pChute == chute)
             {
                 if (lastFrame != Time.frameCount)
                 {

--- a/Source/Modules/ModuleAutoCutDrogue.cs
+++ b/Source/Modules/ModuleAutoCutDrogue.cs
@@ -4,6 +4,8 @@
     Originally By:  Jsolson
     Originally For: Bluedog Design Bureau
 */
+using HarmonyLib;
+using System;
 using System.Linq;
 using UnityEngine;
 
@@ -22,6 +24,10 @@ namespace KSPCommunityPartModules.Modules
         public bool triggered = false;
 
         private ModuleParachute chute = null;
+
+        // Technically this creates an edge case where if two loaded vessels deploy a main parachute at the same time only one of the vessels will cut its drogue chutes,
+        // but I feel like its unlikely enough to not warrent the effort required to fix it.
+        private static int lastFrame;
         private bool IsChuteDeployed(ModuleParachute pParachute) => pParachute.deploymentState == ModuleParachute.deploymentStates.DEPLOYED
                                                                  || pParachute.deploymentState == ModuleParachute.deploymentStates.SEMIDEPLOYED;
         public override void OnStart(StartState state)
@@ -32,33 +38,68 @@ namespace KSPCommunityPartModules.Modules
 
             Fields[nameof(autoCutDrogue)].guiActive = !isDrogueChute;
             Fields[nameof(autoCutDrogue)].guiActiveEditor = !isDrogueChute;
+
+            if (!isDrogueChute) ModuleParachuteEvents.OnDeployed += OnParachuteDeployed; 
+            if (!isDrogueChute) ModuleParachuteEvents.OnRepacked += OnParachuteRepacked;
         }
 
-        public void FixedUpdate()
+        public void OnDestroy()
         {
-            if (isDrogueChute || chute == null)
-            {
-                this.isEnabled = false;
-                this.enabled = false;
-                return;
-            }
+            ModuleParachuteEvents.OnDeployed -= OnParachuteDeployed;
+            ModuleParachuteEvents.OnRepacked -= OnParachuteRepacked;
+        }
 
-            if (IsChuteDeployed(chute))
+        private void OnParachuteDeployed(ModuleParachute pChute)
+        {
+            if (pChute == chute && !triggered && lastFrame != Time.frameCount)
             {
-                if (!triggered)
+                var drogues = vessel.FindPartModulesImplementing<ModuleAutoCutDrogue>().Where(d => d.isDrogueChute && d.chute != null);
+                foreach (ModuleAutoCutDrogue d in drogues)
                 {
-                    var drogues = vessel.FindPartModulesImplementing<ModuleAutoCutDrogue>().Where(d => d.isDrogueChute && d.chute != null);
-                    foreach (ModuleAutoCutDrogue d in drogues)
-                    {
-                        if (IsChuteDeployed(d.chute)) d.chute.CutParachute();
-                    }
-                    triggered = true;
+                    if (IsChuteDeployed(d.chute)) d.chute.CutParachute();
                 }
+                lastFrame = Time.frameCount;
+                triggered = true;
             }
-            else if (chute.deploymentState == ModuleParachute.deploymentStates.STOWED)
-            {
-                triggered = false;
-            }
+        }
+
+        private void OnParachuteRepacked(ModuleParachute pChute)
+        {
+            if (pChute == chute && triggered) triggered = false;
+        }
+    }
+
+    [HarmonyPatch(typeof(ModuleParachute))]
+    internal class ModuleParachuteEvents
+    {
+        public static void ModuleManagerPostLoad()
+        {
+            Harmony harmony = new Harmony("KSPCommunityPartModules");
+            harmony.PatchAll();
+        }
+
+        public static event Action<ModuleParachute> OnDeployed;
+        public static event Action<ModuleParachute> OnRepacked;
+
+        [HarmonyPostfix]
+        [HarmonyPatch("OnParachuteSemiDeployed")]
+        static void RaiseEventOnSemiDeployed(ModuleParachute __instance)
+        {
+            OnDeployed?.Invoke(__instance);
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("OnParachuteFullyDeployed")]
+        static void RaiseEventOnFullyDeployed(ModuleParachute __instance)
+        {
+            OnDeployed?.Invoke(__instance);
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("Repack")]
+        static void RaiseEventOnRepack(ModuleParachute __instance)
+        {
+            OnRepacked?.Invoke(__instance);
         }
     }
 }


### PR DESCRIPTION
- Improved performance of ModuleAutoCutDrogue by harmony patching events to fire when the chutes deploy instead of polling every frame.

Fixes #9 