### PR TITLE
V0.3.0

### DIFF
--- a/Source/HarmonyPatches/ModuleParachutePatch.cs
+++ b/Source/HarmonyPatches/ModuleParachutePatch.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using System;
+
+namespace KSPCommunityPartModules.HarmonyPatches
+{
+    [HarmonyPatch(typeof(ModuleParachute))]
+    public class ModuleParachuteEvents
+    {
+        public static void ModuleManagerPostLoad()
+        {
+            Harmony harmony = new Harmony("KSPCommunityPartModules.ModuleParachutePatch");
+            harmony.PatchAll();
+        }
+
+        public static event Action<ModuleParachute> OnDeployed;
+        public static event Action<ModuleParachute> OnRepacked;
+
+        [HarmonyPostfix]
+        [HarmonyPatch("OnParachuteSemiDeployed")]
+        static void RaiseEventOnSemiDeployed(ModuleParachute __instance)
+        {
+            OnDeployed?.Invoke(__instance);
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("OnParachuteFullyDeployed")]
+        static void RaiseEventOnFullyDeployed(ModuleParachute __instance)
+        {
+            OnDeployed?.Invoke(__instance);
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("Repack")]
+        static void RaiseEventOnRepack(ModuleParachute __instance)
+        {
+            OnRepacked?.Invoke(__instance);
+        }
+    }
+}

--- a/Source/KSPCommunityPartModules.csproj
+++ b/Source/KSPCommunityPartModules.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Compile Include="HarmonyPatches\ModuleParachutePatch.cs" />
     <Compile Include="Modules\ModuleAutoCutDrogue.cs" />
+    <Compile Include="Modules\ModuleCenterFollowTransform.cs" />
     <Compile Include="Modules\ModuleCoPFollowTransform.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Source/KSPCommunityPartModules.csproj
+++ b/Source/KSPCommunityPartModules.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="KSPBuildTools" Version="0.0.2-alpha.7" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HarmonyPatches\ModuleParachutePatch.cs" />
     <Compile Include="Modules\ModuleAutoCutDrogue.cs" />
     <Compile Include="Modules\ModuleCoPFollowTransform.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/Modules/ModuleAutoCutDrogue.cs
+++ b/Source/Modules/ModuleAutoCutDrogue.cs
@@ -4,10 +4,9 @@
     Originally By:  Jsolson
     Originally For: Bluedog Design Bureau
 */
-using HarmonyLib;
-using System;
 using System.Linq;
 using UnityEngine;
+using KSPCommunityPartModules.HarmonyPatches;
 
 namespace KSPCommunityPartModules.Modules
 {
@@ -69,40 +68,6 @@ namespace KSPCommunityPartModules.Modules
         private void OnParachuteRepacked(ModuleParachute pChute)
         {
             if (triggered && pChute == chute) triggered = false;
-        }
-    }
-
-    [HarmonyPatch(typeof(ModuleParachute))]
-    internal class ModuleParachuteEvents
-    {
-        public static void ModuleManagerPostLoad()
-        {
-            Harmony harmony = new Harmony("KSPCommunityPartModules");
-            harmony.PatchAll();
-        }
-
-        public static event Action<ModuleParachute> OnDeployed;
-        public static event Action<ModuleParachute> OnRepacked;
-
-        [HarmonyPostfix]
-        [HarmonyPatch("OnParachuteSemiDeployed")]
-        static void RaiseEventOnSemiDeployed(ModuleParachute __instance)
-        {
-            OnDeployed?.Invoke(__instance);
-        }
-
-        [HarmonyPostfix]
-        [HarmonyPatch("OnParachuteFullyDeployed")]
-        static void RaiseEventOnFullyDeployed(ModuleParachute __instance)
-        {
-            OnDeployed?.Invoke(__instance);
-        }
-
-        [HarmonyPostfix]
-        [HarmonyPatch("Repack")]
-        static void RaiseEventOnRepack(ModuleParachute __instance)
-        {
-            OnRepacked?.Invoke(__instance);
         }
     }
 }

--- a/Source/Modules/ModuleCenterFollowTransform.cs
+++ b/Source/Modules/ModuleCenterFollowTransform.cs
@@ -15,12 +15,15 @@ namespace KSPCommunityPartModules.Modules
 
         [KSPField]
         public bool enableCoP = false;
+        private bool wasEnabledCoP;
 
         [KSPField]
         public bool enableCoM = false;
+        private bool wasEnabledCoM;
 
         [KSPField]
         public bool enableCoL = false;
+        private bool wasEnabledCoL;
 
         [KSPField]
         public string transformName;
@@ -28,7 +31,6 @@ namespace KSPCommunityPartModules.Modules
         [SerializeField]
         private Transform followTransform;
 
-        // TODO: Reset offset to prefab value if B9PS disables one of the fields.
         public override void OnLoad(ConfigNode node)
         {
             bool anyModeActive = enableCoP || enableCoM || enableCoL;
@@ -51,7 +53,14 @@ namespace KSPCommunityPartModules.Modules
                 if (enableCoM) part.CoMOffset = part.partInfo.partPrefab.CoMOffset;
                 if (enableCoL) part.CoLOffset = part.partInfo.partPrefab.CoLOffset;
             }
-            
+            // Set offets back to the values in the prefab if the mode is disabled after initial initialisation; e.g. B9PS
+            if (!enableCoP && wasEnabledCoP) part.CoPOffset = part.partInfo.partPrefab.CoPOffset;
+            if (!enableCoM && wasEnabledCoM) part.CoMOffset = part.partInfo.partPrefab.CoMOffset;
+            if (!enableCoL && wasEnabledCoL) part.CoLOffset = part.partInfo.partPrefab.CoLOffset;
+            wasEnabledCoP = enableCoP;
+            wasEnabledCoM = enableCoM;
+            wasEnabledCoL = enableCoL;
+
             // NOTE: isEnabled will be persisted to the save file, but we want to treat it purely as runtime state
             isEnabled = followTransform != null && anyModeActive;
             enabled = followTransform != null && anyModeActive && HighLogic.LoadedSceneIsFlight;

--- a/Source/Modules/ModuleCenterFollowTransform.cs
+++ b/Source/Modules/ModuleCenterFollowTransform.cs
@@ -1,0 +1,78 @@
+﻿/*
+    Usecase:        Making the Center of Pressure, Mass or Lift follow a transform on the same part.
+    Example:        BoringCrewServices Starliner main parachutes,
+                    StarshipExpansionProject Starship Flaps
+    Originally By:  Sofie Brink & JonnyOThan
+    Originally For: KSPCommunityPartModules
+*/
+using UnityEngine;
+
+namespace KSPCommunityPartModules.Modules
+{
+    public class ModuleCenterFollowTransform : PartModule
+    {
+        public const string MODULENAME = nameof(ModuleCenterFollowTransform);
+
+        [KSPField]
+        public bool enableCoP = false;
+
+        [KSPField]
+        public bool enableCoM = false;
+
+        [KSPField]
+        public bool enableCoL = false;
+
+        [KSPField]
+        public string transformName;
+
+        [SerializeField]
+        private Transform followTransform;
+
+        // TODO: Reset offset to prefab value if B9PS disables one of the fields.
+        public override void OnLoad(ConfigNode node)
+        {
+            bool anyModeActive = enableCoP || enableCoM || enableCoL;
+
+            if (followTransform == null || followTransform.name != transformName)
+            {
+                if (transformName != null) followTransform = part.FindModelTransform(transformName);
+                if (followTransform == null) Debug.LogError($"[{MODULENAME}] transformName '{transformName}' was empty or does not exist on part '{part.partInfo?.name}'");
+            }
+            if (!anyModeActive)
+            {
+                Debug.LogWarning($"[{MODULENAME}] no center is following transformName '{transformName}' on part '{part.partInfo?.name}'");
+            }
+
+            if (followTransform == null && part.partInfo != null)
+            {
+                // this may be important if someone is swapping out versions of this module with B9PS
+                // Note this probably isn't correct for parts that also have modules that mess with this field (e.g. ModuleProceduralFairing)
+                if (enableCoP) part.CoPOffset = part.partInfo.partPrefab.CoPOffset;
+                if (enableCoM) part.CoMOffset = part.partInfo.partPrefab.CoMOffset;
+                if (enableCoL) part.CoLOffset = part.partInfo.partPrefab.CoLOffset;
+            }
+            
+            // NOTE: isEnabled will be persisted to the save file, but we want to treat it purely as runtime state
+            isEnabled = followTransform != null && anyModeActive;
+            enabled = followTransform != null && anyModeActive && HighLogic.LoadedSceneIsFlight;
+        }
+
+        public void FixedUpdate()
+        {
+            // Note that we shouldn't ever get here if the transform just didn't exist
+            // But it's certainly possible for *something* to delete it later
+            if (followTransform == null)
+            {
+                isEnabled = false;
+                enabled = false;
+            }
+            else
+            {
+                Vector3 offset = part.transform.InverseTransformPoint(followTransform.position);
+                if (enableCoP) part.CoPOffset = offset;
+                if (enableCoM) part.CoMOffset = offset;
+                if (enableCoL) part.CoLOffset = offset;
+            }
+        }
+    }
+}

--- a/Source/Modules/ModuleCoPFollowTransform.cs
+++ b/Source/Modules/ModuleCoPFollowTransform.cs
@@ -20,6 +20,7 @@ namespace KSPCommunityPartModules.Modules
 
         public override void OnLoad(ConfigNode node)
         {
+            Debug.LogWarning($"[{MODULENAME}] This module is deprecated! please use ModuleCenterFollowTransform instead!");
             if (followTransform == null || followTransform.name != transformName)
             {
                 if (transformName != null) followTransform = part.FindModelTransform(transformName);


### PR DESCRIPTION
Fixes #15 
- Removed harmony patch for ModuleAutoCutDrogue from the module's cs file and moved it to its own harmony patches folder.
- Added ModuleCenterFollowTransform to replace ModuleCoPFollowTransform.
- Deprecated ModuleCoPFollowTransform.